### PR TITLE
Custom identity example with custom prompt

### DIFF
--- a/examples/custom-account/dist/bundle.js
+++ b/examples/custom-account/dist/bundle.js
@@ -26,7 +26,9 @@ wallet.registerAccountMessageHandler(async (origin, req) => {
     case 'wallet_signTypedData':
     case 'wallet_signTypedData_v3':
     case 'wallet_signTypedData_v4':
-      const result = await prompt(`The site from ${origin} requests you sign this with your offline strategy:\n${JSON.stringify(req)}`)
+      const result = await prompt(`<div style="width: 100%;overflow-wrap: break-word;">
+        The site from <span style="font-weight: 900;color: #037DD6;"><a href="${origin}">${origin}</a></span> requests you sign this with your offline strategy:\n${JSON.stringify(req)}
+        </div>`)
       return result
     default:
       throw rpcErrors.methodNotFound(req)

--- a/examples/custom-account/dist/bundle.js
+++ b/examples/custom-account/dist/bundle.js
@@ -26,9 +26,9 @@ wallet.registerAccountMessageHandler(async (origin, req) => {
     case 'wallet_signTypedData':
     case 'wallet_signTypedData_v3':
     case 'wallet_signTypedData_v4':
-      const result = await prompt(`<div style="width: 100%;overflow-wrap: break-word;">
+      const result = await prompt({ customHtml: `<div style="width: 100%;overflow-wrap: break-word;">
         The site from <span style="font-weight: 900;color: #037DD6;"><a href="${origin}">${origin}</a></span> requests you sign this with your offline strategy:\n${JSON.stringify(req)}
-        </div>`)
+        </div>`})
       return result
     default:
       throw rpcErrors.methodNotFound(req)

--- a/examples/custom-account/index.html
+++ b/examples/custom-account/index.html
@@ -85,7 +85,7 @@ async function tip () {
       method: 'eth_sendTransaction',
       params: [{
         from: account,
-        value: '0x100000000000000000',
+        value: '0x10000000000000',
         to: '0x55e2780588aa5000f464f700d2676fd0a22ee160',
       }]
     })

--- a/examples/custom-account/index.js
+++ b/examples/custom-account/index.js
@@ -25,7 +25,9 @@ wallet.registerAccountMessageHandler(async (origin, req) => {
     case 'wallet_signTypedData':
     case 'wallet_signTypedData_v3':
     case 'wallet_signTypedData_v4':
-      const result = await prompt(`The site from ${origin} requests you sign this with your offline strategy:\n${JSON.stringify(req)}`)
+      const result = await prompt(`<div style="width: 100%;overflow-wrap: break-word;">
+        The site from <span style="font-weight: 900;color: #037DD6;"><a href="${origin}">${origin}</a></span> requests you sign this with your offline strategy:\n${JSON.stringify(req)}
+        </div>`)
       return result
     default:
       throw rpcErrors.methodNotFound(req)

--- a/examples/custom-account/index.js
+++ b/examples/custom-account/index.js
@@ -25,9 +25,9 @@ wallet.registerAccountMessageHandler(async (origin, req) => {
     case 'wallet_signTypedData':
     case 'wallet_signTypedData_v3':
     case 'wallet_signTypedData_v4':
-      const result = await prompt(`<div style="width: 100%;overflow-wrap: break-word;">
+      const result = await prompt({ customHtml: `<div style="width: 100%;overflow-wrap: break-word;">
         The site from <span style="font-weight: 900;color: #037DD6;"><a href="${origin}">${origin}</a></span> requests you sign this with your offline strategy:\n${JSON.stringify(req)}
-        </div>`)
+        </div>`})
       return result
     default:
       throw rpcErrors.methodNotFound(req)


### PR DESCRIPTION
This PR adds to https://github.com/MetaMask/mm-plugin/pull/31 to take advantage of the support for custom html in prompts added with https://github.com/MetaMask/metamask-plugin-beta/pull/86

Code such as  `<div style="width: 100%;overflow-wrap: break-word;">
        The site from <span style="font-weight: 900;color: #037DD6;"><a href="${origin}">${origin}</a></span> requests you sign this with your offline strategy:\n${JSON.stringify(req)}
        </div>`

can be passed to the prompt method to generate a prompt in metamask that looks like:

![Screenshot from 2019-10-31 16-44-34](https://user-images.githubusercontent.com/7499938/67979494-59014b00-fbff-11e9-8840-90c203f43111.png)
