### PR TITLE
Add strip code comments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Options (build):
                                                  [string] [default: "bundle.js"]
   --sourceMaps                    Whether building outputs sourcemaps
                                                       [boolean] [default: false]
+  --stripComments, --strip        Whether to remove code comments from bundle
+                                                      [boolean] [default: false]
   --port, -p                      Local server port for testing
                                              [number] [required] [default: 8081]
   --eval, -e                      Attempt to evaluate Snap bundle in SES

--- a/package-lock.json
+++ b/package-lock.json
@@ -2465,6 +2465,11 @@
         "ansi-regex": "^4.1.0"
       }
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw=="
+    },
     "subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "devDependencies": {},
   "bin": {
-    "snap2": "./snaps-cli.js"
+    "snap": "./snaps-cli.js",
+    "mm-snap": "./snaps-cli.js",
+    "mm-plugin": "./snaps-cli.js"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   },
   "devDependencies": {},
   "bin": {
-    "snap": "./snaps-cli.js",
-    "mm-snap": "./snaps-cli.js",
-    "mm-plugin": "./snaps-cli.js"
+    "snap2": "./snaps-cli.js"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",
@@ -35,6 +33,7 @@
     "rfdc": "^1.1.4",
     "serve-handler": "^6.1.1",
     "ses": "^0.6.4",
+    "strip-comments": "^2.0.1",
     "terser": "^4.3.1",
     "yargs": "^14.0.0"
   }

--- a/snaps-cli.js
+++ b/snaps-cli.js
@@ -203,6 +203,7 @@ yargs
         .option('dist', builders.dist)
         .option('outfileName', builders.outfileName)
         .option('sourceMaps', builders.sourceMaps)
+        .option('stripComments', builders.stripComments)
     },
     argv => watch(argv)
   )

--- a/snaps-cli.js
+++ b/snaps-cli.js
@@ -67,6 +67,13 @@ const builders = {
     default: false,
   },
 
+  stripComments: {
+    alias: 'strip',
+    describe: 'Whether to remove code comments from bundle',
+    type: 'boolean',
+    default: false,
+  },
+
   outfileName: {
     alias: 'n',
     describe: 'Output file name',
@@ -144,6 +151,7 @@ yargs
         .option('dist', builders.dist)
         .option('outfileName', builders.outfileName)
         .option('sourceMaps', builders.sourceMaps)
+        .option('stripComments', builders.stripComments)
         .option('port', builders.port)
         .option('eval', builders.eval)
         .option('manifest', builders.manifest)

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,7 @@
 
 const fs = require('fs')
 const browserify = require('browserify')
+const stripComments = require('strip-comments')
 // const terser = require('terser')
 
 const { logError } = require('./utils')
@@ -16,6 +17,7 @@ module.exports = {
  * @param {string} dest - The destination file path
  * @param {object} argv - argv from Yargs
  * @param {boolean} argv.sourceMaps - Whether to output sourcemaps
+ * @param {boolean} argv.stripComments - Whether to remove comments from code
  */
 function bundle(src, dest, argv) {
 
@@ -41,7 +43,7 @@ function bundle(src, dest, argv) {
         // }
         // closeBundleStream(bundleStream, code.toString())
 
-        closeBundleStream(bundleStream, bundle ? bundle.toString() : null)
+        closeBundleStream(bundleStream, bundle ? bundle.toString() : null, {stripComments: argv.stripComments})
         .then(() => {
           if (bundle) {
             console.log(`Build success: '${src}' bundled as '${dest}'!`)
@@ -75,9 +77,11 @@ function createBundleStream (dest) {
  *
  * @param {object} stream - The write stream
  * @param {string} bundleString - The bundle string
+ * @param {object} options - post process options
+ * @param {boolean} options.stripComments
  */
-async function closeBundleStream (stream, bundleString) {
-  stream.end(postProcess(bundleString), (err) => {
+async function closeBundleStream (stream, bundleString, options) {
+  stream.end(postProcess(bundleString, options), (err) => {
     if (err) throw err
   })
 }
@@ -91,15 +95,21 @@ async function closeBundleStream (stream, bundleString) {
  * - handles certain Babel-related edge cases
  * 
  * @param {string} bundleString - The bundle string
+ * @param {object} options - post process options
+ * @param {boolean} options.stripComments
  * @returns {string} - The postprocessed bundle string
  */
-function postProcess (bundleString) {
+function postProcess (bundleString, options) {
 
   if (typeof bundleString !== 'string') {
     return null
   }
 
   bundleString = bundleString.trim()
+
+  if (options.stripComments) {
+    bundleString = stripComments(bundleString)
+  }
 
   // .import( => ["import"](
   bundleString = bundleString.replace(/\.import\(/g, '["import"](')


### PR DESCRIPTION
This is to mitigate:
- https://github.com/Agoric/SES-shim/issues/234
- https://github.com/Agoric/SES-shim/issues/235

TLDR cli option to allow users to specify whether to remove all code comments from bundle to fix ses evaluation of libraries that contains code in comments 