### PR TITLE
Fix linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,16 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
-    semi: [2, 'always'],
-    'space-before-function-paren': 'off',
+    // TODO: Remove these once they've landed on the main config
+    semi: ['error', 'always'],
+    'space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'always',
+        asyncArrow: 'always',
+        named: 'never',
+      },
+    ],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,18 +1,17 @@
 module.exports = {
-  env: {
-    node: true,
-  },
   extends: [
     '@metamask/eslint-config',
-    '@metamask/eslint-config/config/jest',
     '@metamask/eslint-config/config/nodejs',
-    '@metamask/eslint-config/config/typescript',
   ],
   plugins: [
     'json',
   ],
   parserOptions: {
     ecmaVersion: 2018,
+  },
+  rules: {
+    semi: [2, 'always'],
+    'space-before-function-paren': 'off',
   },
   overrides: [
     {
@@ -33,6 +32,12 @@ module.exports = {
         'snaps-cli.js',
         'src/**/*.js',
       ],
+      env: {
+        node: true,
+      },
+      globals: {
+        snaps: true,
+      },
       rules: {
         'node/no-process-exit': 'off',
       },
@@ -41,6 +46,12 @@ module.exports = {
       files: [
         'examples/**/*.js',
       ],
+      env: {
+        browser: true,
+      },
+      globals: {
+        wallet: true,
+      },
       rules: {
         'no-alert': 'off',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,19 +16,6 @@ module.exports = {
   overrides: [
     {
       files: [
-        '*.js',
-        '*.json',
-      ],
-      parserOptions: {
-        sourceType: 'script',
-      },
-      rules: {
-        '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
-      },
-    },
-    {
-      files: [
         'snaps-cli.js',
         'src/**/*.js',
       ],

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 temp
 examples/*/dist
+*.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.DS_Store
-.python-version
-node_modules
-scripts/development
-temp
-dist

--- a/examples/async-inpage-api/index.js
+++ b/examples/async-inpage-api/index.js
@@ -20,7 +20,7 @@ wallet.registerApiRequestHandler(async (origin) => {
           pingListeners.push(callback);
           return true;
         default:
-          throw rpcErrors.methodNotFound(requestObject);
+          throw rpcErrors.methodNotFound(eventName);
       }
     },
   };

--- a/examples/identicon/index.js
+++ b/examples/identicon/index.js
@@ -2,7 +2,6 @@ wallet.registerRpcMessageHandler(async (_originString, requestObject) => {
   switch (requestObject.method) {
     case 'setUseBlockie':
       return wallet.setUseBlockie(requestObject.params[0]);
-      break;
     default:
       throw new Error('Method not found. From index.js');
   }

--- a/examples/identicon/script.js
+++ b/examples/identicon/script.js
@@ -1,3 +1,5 @@
+/* global ethereum */
+
 const origin = 'https://mountainous-dentist.glitch.me/package.json';
 const pluginOrigin = `wallet_plugin_${origin}`;
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.4.1",
   "description": "A CLI for developing MetaMask Snaps.",
   "main": "snaps-cli.js",
+  "files": [
+    "snaps-cli.js",
+    "src/*"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "generateInitTemplate": "node ./scripts/development/generateInitTemplate.js",
@@ -23,7 +27,7 @@
     "@metamask/eslint-config": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.13.0",
-    "eslint": "^7.7.0",
+    "eslint": "^7.18.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-json": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,10 @@
   },
   "devDependencies": {
     "@metamask/eslint-config": "^4.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.13.0",
-    "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^7.18.0",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-json": "^2.1.2",
-    "eslint-plugin-node": "^11.1.0",
-    "typescript": "^4.1.3"
+    "eslint-plugin-node": "^11.1.0"
   },
   "bin": {
     "snap": "./snaps-cli.js",

--- a/scripts/buildExamples.js
+++ b/scripts/buildExamples.js
@@ -7,7 +7,7 @@ const EXAMPLES_PATH = 'examples';
 
 buildExamples();
 
-async function buildExamples () {
+async function buildExamples() {
   const examplesDir = await fs.readdir(EXAMPLES_PATH);
 
   examplesDir.forEach(async (exampleFile) => {

--- a/scripts/buildExamples.js
+++ b/scripts/buildExamples.js
@@ -1,4 +1,3 @@
-
 const { promises: fs } = require('fs');
 const path = require('path');
 
@@ -6,46 +5,35 @@ const { bundle } = require('../src/build');
 
 const EXAMPLES_PATH = 'examples';
 
-fs.readdir(EXAMPLES_PATH, (err, results) => {
+buildExamples();
 
-  if (err) {
-    throw err;
-  }
+async function buildExamples () {
+  const examplesDir = await fs.readdir(EXAMPLES_PATH);
 
-  results.forEach((examplesFile) => {
+  examplesDir.forEach(async (exampleFile) => {
+    const exampleFilePath = path.resolve(EXAMPLES_PATH, exampleFile);
+    const exampleFileStat = await fs.stat(exampleFilePath);
 
-    let exampleFile = examplesFiles;
-    exampleFile = path.resolve(EXAMPLES_PATH, examplesFile);
+    if (exampleFileStat.isDirectory()) {
+      try {
+        const srcPath = path.resolve(exampleFilePath, 'index.js');
+        const pkgPath = path.resolve(exampleFilePath, 'package.json');
+        const pkgStat = await fs.stat(pkgPath);
+        const srcStat = await fs.stat(srcPath);
 
-    fs.stat(exampleFile, (error, stat) => {
-
-      if (error) {
-        throw error;
-      }
-
-      if (stat?.isDirectory()) {
-
-        try {
-
-          const srcPath = path.resolve(exampleFile, 'index.js');
-          const pkgPath = path.resolve(exampleFile, 'package.json');
-          const pkgStat = await fs.stat(pkgPath);
-          const srcStat = await fs.stat(srcPath);
-
-          if (pkgStat?.isFile() && srcStat?.isFile()) {
-            bundle(
-              srcPath,
-              path.resolve(exampleFile, 'dist/bundle.js'),
-              { sourceMaps: true },
-            );
-          } else {
-            throw new Error();
-          }
-        } catch (errors) {
-          console.log(`Invalid example folder found: ${exampleFile}`);
-          console.log(`Ensure it has valid 'package.json' and 'index.js' files.`);
+        if (pkgStat.isFile() && srcStat.isFile()) {
+          bundle(
+            srcPath,
+            path.resolve(exampleFilePath, 'dist/bundle.js'),
+            { sourceMaps: true },
+          );
+        } else {
+          throw new Error();
         }
+      } catch (errors) {
+        console.log(`Invalid example folder found: ${exampleFile}`);
+        console.log(`Ensure it has valid 'package.json' and 'index.js' files.`);
       }
-    });
+    }
   });
-});
+}

--- a/scripts/development/generateInitTemplate.js
+++ b/scripts/development/generateInitTemplate.js
@@ -1,16 +1,19 @@
-
 const { promises: fs } = require('fs');
 const path = require('path');
 
 const EXAMPLE_PATH = 'examples/hello-snaps';
 const TEMPLATE_PATH = 'src/initTemplate.json';
 
-const html = await fs.readFile(path.join(EXAMPLE_PATH, 'index.html')).toString();
-const js = await fs.readFile(path.join(EXAMPLE_PATH, 'index.js')).toString();
+generateInitTemplate();
 
-await fs.writeFile(TEMPLATE_PATH, JSON.stringify({
-  html,
-  js,
-}, null, 2));
+async function generateInitTemplate() {
+  const html = await fs.readFile(path.join(EXAMPLE_PATH, 'index.html')).toString();
+  const js = await fs.readFile(path.join(EXAMPLE_PATH, 'index.js')).toString();
 
-console.log('success: wrote src/initTemplate.json');
+  await fs.writeFile(TEMPLATE_PATH, JSON.stringify({
+    html,
+    js,
+  }, null, 2));
+
+  console.log('success: wrote src/initTemplate.json');
+}

--- a/snaps-cli.js
+++ b/snaps-cli.js
@@ -117,118 +117,121 @@ const builders = {
   },
 };
 
-applyConfig();
+main();
 
 // application
+async function main () {
+  await applyConfig();
 
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-yargs
-  .usage('Usage: $0 <command> [options]')
-  .example('$0 init', `\tInitialize Snap package from scratch`)
-  .example('$0 build -s index.js -d out', `\tBuild 'index.js' as './out/bundle.js'`)
-  .example('$0 build -s index.js -d out -n snap.js', `\tBuild 'index.js' as './out/snap.js'`)
-  .example('$0 serve -r out', `\tServe files in './out' on port 8080`)
-  .example('$0 serve -r out -p 9000', `\tServe files in './out' on port 9000`)
-  .example('$0 watch -s index.js -d out', `\tRebuild './out/bundle.js' on changes to files in 'index.js' parent and child directories`)
+  // eslint-disable-next-line no-unused-expressions
+  yargs
+    .usage('Usage: $0 <command> [options]')
+    .example('$0 init', `\tInitialize Snap package from scratch`)
+    .example('$0 build -s index.js -d out', `\tBuild 'index.js' as './out/bundle.js'`)
+    .example('$0 build -s index.js -d out -n snap.js', `\tBuild 'index.js' as './out/snap.js'`)
+    .example('$0 serve -r out', `\tServe files in './out' on port 8080`)
+    .example('$0 serve -r out -p 9000', `\tServe files in './out' on port 9000`)
+    .example('$0 watch -s index.js -d out', `\tRebuild './out/bundle.js' on changes to files in 'index.js' parent and child directories`)
 
-  .command(
-    ['init', 'i'],
-    'Initialize Snap package',
-    (yarg) => {
-      yarg
-        .option('src', builders.src)
-        .option('dist', builders.dist)
-        .option('outfileName', builders.outfileName)
-        .option('port', builders.port);
-    },
-    (argv) => init(argv),
-  )
+    .command(
+      ['init', 'i'],
+      'Initialize Snap package',
+      (yarg) => {
+        yarg
+          .option('src', builders.src)
+          .option('dist', builders.dist)
+          .option('outfileName', builders.outfileName)
+          .option('port', builders.port);
+      },
+      (argv) => init(argv),
+    )
 
-  .command(
-    ['build', 'b'],
-    'Build Snap from source',
-    (yarg) => {
-      yarg
-        .option('src', builders.src)
-        .option('dist', builders.dist)
-        .option('outfileName', builders.outfileName)
-        .option('sourceMaps', builders.sourceMaps)
-        .option('port', builders.port)
-        .option('eval', builders.eval)
-        .option('manifest', builders.manifest)
-        .option('populate', builders.populate)
-        .option('environment', builders.environment)
-        .implies('populate', 'manifest');
-    },
-    (argv) => build(argv),
-  )
+    .command(
+      ['build', 'b'],
+      'Build Snap from source',
+      (yarg) => {
+        yarg
+          .option('src', builders.src)
+          .option('dist', builders.dist)
+          .option('outfileName', builders.outfileName)
+          .option('sourceMaps', builders.sourceMaps)
+          .option('port', builders.port)
+          .option('eval', builders.eval)
+          .option('manifest', builders.manifest)
+          .option('populate', builders.populate)
+          .option('environment', builders.environment)
+          .implies('populate', 'manifest');
+      },
+      (argv) => build(argv),
+    )
 
-  .command(
-    ['eval', 'e'],
-    builders.eval.describe,
-    (yarg) => {
-      yarg
-        .option('bundle', builders.bundle)
-        .option('environment', builders.environment);
-    },
-    (argv) => snapEval(argv),
-  )
+    .command(
+      ['eval', 'e'],
+      builders.eval.describe,
+      (yarg) => {
+        yarg
+          .option('bundle', builders.bundle)
+          .option('environment', builders.environment);
+      },
+      (argv) => snapEval(argv),
+    )
 
-  .command(
-    ['manifest', 'm'],
-    builders.manifest.describe,
-    (yarg) => {
-      yarg
-        .option('dist', builders.dist)
-        .option('port', builders.port)
-        .option('populate', builders.populate);
-    },
-    (argv) => manifest(argv),
-  )
+    .command(
+      ['manifest', 'm'],
+      builders.manifest.describe,
+      (yarg) => {
+        yarg
+          .option('dist', builders.dist)
+          .option('port', builders.port)
+          .option('populate', builders.populate);
+      },
+      (argv) => manifest(argv),
+    )
 
-  .command(
-    ['serve', 's'],
-    'Locally serve Snap file(s) for testing',
-    (yarg) => {
-      yarg
-        .option('root', builders.root)
-        .option('port', builders.port);
-    },
-    (argv) => serve(argv),
-  )
+    .command(
+      ['serve', 's'],
+      'Locally serve Snap file(s) for testing',
+      (yarg) => {
+        yarg
+          .option('root', builders.root)
+          .option('port', builders.port);
+      },
+      (argv) => serve(argv),
+    )
 
-  .command(
-    ['watch', 'w'],
-    'Build Snap on change',
-    (yarg) => {
-      yarg
-        .option('src', builders.src)
-        .option('dist', builders.dist)
-        .option('outfileName', builders.outfileName)
-        .option('sourceMaps', builders.sourceMaps)
-        .option('environment', builders.environment);
-    },
-    (argv) => watch(argv),
-  )
+    .command(
+      ['watch', 'w'],
+      'Build Snap on change',
+      (yarg) => {
+        yarg
+          .option('src', builders.src)
+          .option('dist', builders.dist)
+          .option('outfileName', builders.outfileName)
+          .option('sourceMaps', builders.sourceMaps)
+          .option('environment', builders.environment);
+      },
+      (argv) => watch(argv),
+    )
 
-  .option('verboseErrors', builders.verboseErrors)
-  .option('suppressWarnings', builders.suppressWarnings)
-  .demandCommand(1, 'You must specify at least one command.')
-  .strict()
-  .middleware((argv) => {
-    assignGlobals(argv);
-    sanitizeInputs(argv);
-  })
-  .help()
-  .alias('help', 'h')
-  .fail((msg, err, _yargs) => {
-    console.error(msg || err.message);
-    if (err?.stack && snaps.verboseErrors) {
-      console.error(err.stack);
-    }
-    process.exit(1);
-  })
-  .argv;
+    .option('verboseErrors', builders.verboseErrors)
+    .option('suppressWarnings', builders.suppressWarnings)
+    .demandCommand(1, 'You must specify at least one command.')
+    .strict()
+    .middleware((argv) => {
+      assignGlobals(argv);
+      sanitizeInputs(argv);
+    })
+    .help()
+    .alias('help', 'h')
+    .fail((msg, err, _yargs) => {
+      console.error(msg || err.message);
+      if (err && err.stack && snaps.verboseErrors) {
+        console.error(err.stack);
+      }
+      process.exit(1);
+    })
+    .argv;
+}
 
 // misc
 
@@ -264,7 +267,7 @@ function sanitizeInputs(argv) {
  * Attempts to read the config file and apply the config to
  * globals.
  */
-function applyConfig() {
+async function applyConfig() {
 
   // first, attempt to read and apply config from package.json
   let pkg = {};
@@ -277,7 +280,7 @@ function applyConfig() {
 
     if (pkg.web3Wallet) {
       const { bundle } = pkg.web3Wallet;
-      if (bundle?.local) {
+      if (bundle && bundle.local) {
         const { local: bundlePath } = bundle;
         builders.bundle.default = bundlePath;
         let dist;

--- a/snaps-cli.js
+++ b/snaps-cli.js
@@ -120,7 +120,7 @@ const builders = {
 main();
 
 // application
-async function main () {
+async function main() {
   await applyConfig();
 
   // eslint-disable-next-line no-unused-expressions

--- a/src/build.js
+++ b/src/build.js
@@ -1,5 +1,4 @@
-
-const { promises: fs } = require('fs');
+const { promises: fs, createWriteStream } = require('fs');
 const browserify = require('browserify');
 // const terser = require('terser')
 
@@ -65,7 +64,7 @@ function bundle(src, dest, argv) {
  * @returns {object} - The stream
  */
 function createBundleStream(dest) {
-  const stream = fs.createWriteStream(dest, {
+  const stream = createWriteStream(dest, {
     autoClose: false,
     encoding: 'utf8',
   });

--- a/src/commands.js
+++ b/src/commands.js
@@ -193,12 +193,12 @@ function manifest(argv) {
 // eval
 
 async function snapEval(argv) {
-  const { bundles } = argv;
-  await validateFilePath(bundles);
+  const { bundle: bundlePath } = argv;
+  await validateFilePath(bundlePath);
   try {
     // TODO: When supporting multiple environments, evaluate them here.
-    await workerEval(bundle);
-    console.log(`Eval Success: evaluated '${bundle}' in SES!`);
+    await workerEval(bundlePath);
+    console.log(`Eval Success: evaluated '${bundlePath}' in SES!`);
     return true;
   } catch (err) {
     logError(`Snap evaluation error: ${err.message}`, err);

--- a/src/commands.js
+++ b/src/commands.js
@@ -204,7 +204,6 @@ async function snapEval(argv) {
     logError(`Snap evaluation error: ${err.message}`, err);
     process.exit(1);
   }
-  return true;
 }
 
 function workerEval(bundlePath) {

--- a/src/evalWorker.js
+++ b/src/evalWorker.js
@@ -1,10 +1,11 @@
-/* global Compartment, BigInt */
+/* global lockdown, Compartment, BigInt */
 
 const { parentPort } = require('worker_threads');
 const { readFileSync } = require('fs');
 const crypto = require('crypto');
 
-const lockdown = require('ses/lockdown');
+// eslint-disable-next-line import/no-unassigned-import
+require('ses/lockdown');
 
 lockdown({
   mathTaming: 'unsafe',

--- a/src/evalWorker.js
+++ b/src/evalWorker.js
@@ -1,3 +1,5 @@
+/* global Compartment, BigInt */
+
 const { parentPort } = require('worker_threads');
 const { readFileSync } = require('fs');
 const crypto = require('crypto');

--- a/src/init.js
+++ b/src/init.js
@@ -100,7 +100,7 @@ async function asyncPackageInit() {
   }
 
   // run 'npm init'
-  return new Promise((resolve, _reject) => {
+  return new Promise((resolve, reject) => {
     packageInit(process.cwd(), '', {}, (err, data) => {
       if (err) {
         reject(err);

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,4 +1,3 @@
-
 const { promises: fs } = require('fs');
 const pathUtils = require('path');
 const dequal = require('fast-deep-equal');

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -119,7 +119,7 @@ module.exports = async function manifest(argv) {
 
   // check web3Wallet properties
   const { bundle, initialPermissions } = pkg.web3Wallet || {};
-  if (bundle?.local) {
+  if (bundle && bundle.local) {
     if (!(await isFile(bundle.local))) {
       logManifestError(`'bundle.local' does not resolve to a file.`);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@eslint/eslintrc@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
-  integrity sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==
+"@eslint/eslintrc@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.3.0.tgz#d736d6963d7003b6514e6324bec9c602ac340318"
+  integrity sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -664,7 +664,7 @@
     ignore "^4.0.6"
     import-fresh "^3.2.1"
     js-yaml "^3.13.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
@@ -705,12 +705,12 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@typescript-eslint/eslint-plugin@^4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz#5f580ea520fa46442deb82c038460c3dd3524bb6"
-  integrity sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.0.tgz#92db8e7c357ed7d69632d6843ca70b71be3a721d"
+  integrity sha512-IJ5e2W7uFNfg4qh9eHkHRUCbgZ8VKtGwD07kannJvM5t/GU8P8+24NX8gi3Hf5jST5oWPY8kyV1s/WtfiZ4+Ww==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.13.0"
-    "@typescript-eslint/scope-manager" "4.13.0"
+    "@typescript-eslint/experimental-utils" "4.14.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     lodash "^4.17.15"
@@ -718,15 +718,15 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.13.0.tgz#9dc9ab375d65603b43d938a0786190a0c72be44e"
-  integrity sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==
+"@typescript-eslint/experimental-utils@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.0.tgz#5aa7b006736634f588a69ee343ca959cd09988df"
+  integrity sha512-6i6eAoiPlXMKRbXzvoQD5Yn9L7k9ezzGRvzC/x1V3650rUk3c3AOjQyGYyF9BDxQQDK2ElmKOZRD0CbtdkMzQQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.13.0"
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/typescript-estree" "4.13.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/typescript-estree" "4.14.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -741,27 +741,27 @@
     eslint-utils "^2.0.0"
 
 "@typescript-eslint/parser@^4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.13.0.tgz#c413d640ea66120cfcc37f891e8cb3fd1c9d247d"
-  integrity sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.0.tgz#62d4cd2079d5c06683e9bfb200c758f292c4dee7"
+  integrity sha512-sUDeuCjBU+ZF3Lzw0hphTyScmDDJ5QVkyE21pRoBo8iDl7WBtVFS+WDN3blY1CH3SBt7EmYCw6wfmJjF0l/uYg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.13.0"
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/typescript-estree" "4.13.0"
+    "@typescript-eslint/scope-manager" "4.14.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/typescript-estree" "4.14.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
-  integrity sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
+"@typescript-eslint/scope-manager@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.0.tgz#55a4743095d684e1f7b7180c4bac2a0a3727f517"
+  integrity sha512-/J+LlRMdbPh4RdL4hfP1eCwHN5bAhFAGOTsvE6SxsrM/47XQiPSgF5MDgLyp/i9kbZV9Lx80DW0OpPkzL+uf8Q==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/visitor-keys" "4.13.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/visitor-keys" "4.14.0"
 
-"@typescript-eslint/types@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
-  integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
+"@typescript-eslint/types@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.0.tgz#d8a8202d9b58831d6fd9cee2ba12f8a5a5dd44b6"
+  integrity sha512-VsQE4VvpldHrTFuVPY1ZnHn/Txw6cZGjL48e+iBxTi2ksa9DmebKjAeFmTVAYoSkTk7gjA7UqJ7pIsyifTsI4A==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -776,13 +776,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz#cf6e2207c7d760f5dfd8d18051428fadfc37b45e"
-  integrity sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
+"@typescript-eslint/typescript-estree@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.0.tgz#4bcd67486e9acafc3d0c982b23a9ab8ac8911ed7"
+  integrity sha512-wRjZ5qLao+bvS2F7pX4qi2oLcOONIB+ru8RGBieDptq/SudYwshveORwCVU4/yMAd4GK7Fsf8Uq1tjV838erag==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
-    "@typescript-eslint/visitor-keys" "4.13.0"
+    "@typescript-eslint/types" "4.14.0"
+    "@typescript-eslint/visitor-keys" "4.14.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -790,12 +790,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.13.0":
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz#9acb1772d3b3183182b6540d3734143dce9476fe"
-  integrity sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
+"@typescript-eslint/visitor-keys@4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.0.tgz#b1090d9d2955b044b2ea2904a22496849acbdf54"
+  integrity sha512-MeHHzUyRI50DuiPgV9+LxcM52FCJFYjJiWHtXlbyC27b80mfOwKeiKI+MHOTEpcpfmoPFm/vvQS88bYIx6PZTA==
   dependencies:
-    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/types" "4.14.0"
     eslint-visitor-keys "^2.0.0"
 
 JSONStream@^1.0.3:
@@ -1616,8 +1616,6 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-<<<<<<< HEAD
-=======
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
@@ -1713,13 +1711,13 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
-eslint@^7.7.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.17.0.tgz#4ccda5bf12572ad3bf760e6f195886f50569adb0"
-  integrity sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==
+eslint@^7.18.0:
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.18.0.tgz#7fdcd2f3715a41fe6295a16234bd69aed2c75e67"
+  integrity sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.2.2"
+    "@eslint/eslintrc" "^0.3.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -1743,7 +1741,7 @@ eslint@^7.7.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.19"
+    lodash "^4.17.20"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -1755,11 +1753,6 @@ eslint@^7.7.0:
     table "^6.0.4"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
-
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
@@ -1799,7 +1792,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
->>>>>>> add eslint and fixed related errors
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1829,9 +1821,9 @@ fast-deep-equal@^3.1.1:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.1.1:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.4.tgz#d20aefbf99579383e7f3cc66529158c9b98554d3"
-  integrity sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,130 +673,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-4.1.0.tgz#ace2357af2d9c7d04da40a337fc7f4a81a048921"
   integrity sha512-oc4ONdFB1h2yxBebVj4ACYzGzArB8ZQKiFVNCDlYiTCyeQ/GR4+EUwg0KvlO33LlXCRbAhO3CX0nChbvIB8hEw==
 
-"@nodelib/fs.scandir@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
-  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
-  dependencies:
-    "@nodelib/fs.stat" "2.0.4"
-    run-parallel "^1.1.9"
-
-"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
-  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
-
-"@nodelib/fs.walk@^1.2.3":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
-  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
-  dependencies:
-    "@nodelib/fs.scandir" "2.1.4"
-    fastq "^1.6.0"
-
-"@types/json-schema@^7.0.3":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
-  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
-
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@typescript-eslint/eslint-plugin@^4.13.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.0.tgz#92db8e7c357ed7d69632d6843ca70b71be3a721d"
-  integrity sha512-IJ5e2W7uFNfg4qh9eHkHRUCbgZ8VKtGwD07kannJvM5t/GU8P8+24NX8gi3Hf5jST5oWPY8kyV1s/WtfiZ4+Ww==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "4.14.0"
-    "@typescript-eslint/scope-manager" "4.14.0"
-    debug "^4.1.1"
-    functional-red-black-tree "^1.0.1"
-    lodash "^4.17.15"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/experimental-utils@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.0.tgz#5aa7b006736634f588a69ee343ca959cd09988df"
-  integrity sha512-6i6eAoiPlXMKRbXzvoQD5Yn9L7k9ezzGRvzC/x1V3650rUk3c3AOjQyGYyF9BDxQQDK2ElmKOZRD0CbtdkMzQQ==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.14.0"
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/typescript-estree" "4.14.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/experimental-utils@^2.5.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^4.13.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.14.0.tgz#62d4cd2079d5c06683e9bfb200c758f292c4dee7"
-  integrity sha512-sUDeuCjBU+ZF3Lzw0hphTyScmDDJ5QVkyE21pRoBo8iDl7WBtVFS+WDN3blY1CH3SBt7EmYCw6wfmJjF0l/uYg==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.14.0"
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/typescript-estree" "4.14.0"
-    debug "^4.1.1"
-
-"@typescript-eslint/scope-manager@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.14.0.tgz#55a4743095d684e1f7b7180c4bac2a0a3727f517"
-  integrity sha512-/J+LlRMdbPh4RdL4hfP1eCwHN5bAhFAGOTsvE6SxsrM/47XQiPSgF5MDgLyp/i9kbZV9Lx80DW0OpPkzL+uf8Q==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
-
-"@typescript-eslint/types@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.14.0.tgz#d8a8202d9b58831d6fd9cee2ba12f8a5a5dd44b6"
-  integrity sha512-VsQE4VvpldHrTFuVPY1ZnHn/Txw6cZGjL48e+iBxTi2ksa9DmebKjAeFmTVAYoSkTk7gjA7UqJ7pIsyifTsI4A==
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/typescript-estree@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.0.tgz#4bcd67486e9acafc3d0c982b23a9ab8ac8911ed7"
-  integrity sha512-wRjZ5qLao+bvS2F7pX4qi2oLcOONIB+ru8RGBieDptq/SudYwshveORwCVU4/yMAd4GK7Fsf8Uq1tjV838erag==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    "@typescript-eslint/visitor-keys" "4.14.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.14.0":
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.0.tgz#b1090d9d2955b044b2ea2904a22496849acbdf54"
-  integrity sha512-MeHHzUyRI50DuiPgV9+LxcM52FCJFYjJiWHtXlbyC27b80mfOwKeiKI+MHOTEpcpfmoPFm/vvQS88bYIx6PZTA==
-  dependencies:
-    "@typescript-eslint/types" "4.14.0"
-    eslint-visitor-keys "^2.0.0"
 
 JSONStream@^1.0.3:
   version "1.3.5"
@@ -915,11 +795,6 @@ array-includes@^3.1.1:
     get-intrinsic "^1.0.1"
     is-string "^1.0.5"
 
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
-  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
 array.prototype.flat@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
@@ -998,7 +873,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1508,13 +1383,6 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dir-glob@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
-  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
-  dependencies:
-    path-type "^4.0.0"
-
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1659,13 +1527,6 @@ eslint-plugin-import@^2.22.0:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jest@^23.6.0:
-  version "23.20.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
-  integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "^2.5.0"
-
 eslint-plugin-json@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-json/-/eslint-plugin-json-2.1.2.tgz#5bc1c221984583c0c5ff21c488386e8263a6bbb7"
@@ -1686,7 +1547,7 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -1820,18 +1681,6 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1853,13 +1702,6 @@ fast-url-parser@1.1.3:
   integrity sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
   dependencies:
     punycode "^1.3.2"
-
-fastq@^1.6.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.0.tgz#74dbefccade964932cdf500473ef302719c652bb"
-  integrity sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
-  dependencies:
-    reusify "^1.0.4"
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -1946,7 +1788,7 @@ get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0:
+glob-parent@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
@@ -1972,7 +1814,7 @@ glob@^7.1.0, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1995,18 +1837,6 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
-
-globby@^11.0.1:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
-  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
 
 graceful-fs@^4.1.2:
   version "4.2.2"
@@ -2090,7 +1920,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4:
+ignore@^5.1.1:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -2417,7 +2247,7 @@ lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -2444,19 +2274,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
-
-micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -2788,11 +2605,6 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
-path-type@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
-  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -2808,11 +2620,6 @@ picomatch@^2.0.4:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
-
-picomatch@^2.0.5, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -3079,11 +2886,6 @@ resolve@^1.10.1, resolve@^1.13.1, resolve@^1.17.0:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
 rfdc@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
@@ -3103,11 +2905,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-run-parallel@^1.1.9:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
-  integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3129,7 +2926,7 @@ semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
@@ -3205,11 +3002,6 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
-
-slash@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
-  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -3469,18 +3261,6 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tsutils@^3.17.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.19.1.tgz#d8566e0c51c82f32f9c25a4d367cd62409a547a9"
-  integrity sha512-GEdoBf5XI324lu7ycad7s6laADfnAqCw6wLGI+knxvw9vsIYBaJfYdmeCEG3FMMUiSm3OGgNb+m6utsWf5h9Vw==
-  dependencies:
-    tslib "^1.8.1"
-
 tty-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
@@ -3502,11 +3282,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
We exorcised the demons from our `eslint` config, and how this is a temple of clean and syntactical code once again. 🙏 

- Remove the MetaMask TypeScript eslint rules
  - TIL this breaks eslint for JavaScript
- Update eslint config for our different globals and environments
- Remove TypeScript and `jest`-related eslint dependencies and configs
- Fix a lot of eslint errors
- Fix a lot of `async`/`await` syntax errors
  - These were concealed by the eslint demons. Fixing them sometimes involved wrapping `await`:ed expressions in `async` functions.
- Fix `createWriteStream` import (it's not part of `fs.promises`)
- Remove `.npmignore`, add `files` property to package.json
- Update `.gitignore`