### PR TITLE
Fix examples dependency installation in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install deps
+          name: Install snaps-cli deps
           command: |
             .circleci/scripts/deps-install.sh
+      - run:
+          name: Install example deps
+          command: |
+            .circleci/scripts/examples-deps-install.sh
       - run:
           name: Collect yarn install HAR logs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           paths:
           - node_modules
           - build-artifacts
+          - examples/*/node_modules
 
   test-lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install snaps-cli deps
+          name: Install main package deps
           command: |
             .circleci/scripts/deps-install.sh
       - run:

--- a/.circleci/scripts/examples-deps-install.sh
+++ b/.circleci/scripts/examples-deps-install.sh
@@ -8,7 +8,7 @@ set -o pipefail
 cd ./examples
 
 # ref: https://github.com/koalaman/shellcheck/wiki/SC2044
-find . -type d -maxdepth 1 -exec sh -c '
+find . -mindepth 1 -maxdepth 1 -type d -exec sh -c '
     cd "$1"
     yarn --frozen-lockfile --ignore-scripts
   ' sh {} \;

--- a/.circleci/scripts/examples-deps-install.sh
+++ b/.circleci/scripts/examples-deps-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -u
+set -o pipefail
+
+cd ./examples
+
+find . -type d -maxdepth 1 -exec sh -c '
+    cd "$1"
+    yarn --frozen-lockfile --ignore-scripts
+  ' sh {} \;

--- a/.circleci/scripts/examples-deps-install.sh
+++ b/.circleci/scripts/examples-deps-install.sh
@@ -7,6 +7,7 @@ set -o pipefail
 
 cd ./examples
 
+# ref: https://github.com/koalaman/shellcheck/wiki/SC2044
 find . -type d -maxdepth 1 -exec sh -c '
     cd "$1"
     yarn --frozen-lockfile --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "generateInitTemplate": "node ./scripts/development/generateInitTemplate.js",
     "buildExamples": "node ./scripts/buildExamples.js",
     "lint": "eslint . --ext js,json",
-    "lint:fix": "yarn lint --fix",
-    "postinstall": ".circleci/scripts/examples-deps-install.sh"
+    "lint:fix": "yarn lint --fix"
   },
   "author": "Erik Marks <rekmarks@protonmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "buildExamples": "node ./scripts/buildExamples.js",
     "lint": "eslint . --ext js,json",
     "lint:fix": "yarn lint --fix",
-    "postinstall": "./.circleci/scripts/examples-deps-install.sh"
+    "postinstall": ".circleci/scripts/examples-deps-install.sh"
   },
   "author": "Erik Marks <rekmarks@protonmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generateInitTemplate": "node ./scripts/development/generateInitTemplate.js",
     "buildExamples": "node ./scripts/buildExamples.js",
     "lint": "eslint . --ext js,json",
-    "lint:fix": "yarn lint --fix"
+    "lint:fix": "yarn lint --fix",
+    "postinstall": "./.circleci/scripts/examples-deps-install.sh"
   },
   "author": "Erik Marks <rekmarks@protonmail.com>",
   "contributors": [


### PR DESCRIPTION
We're flirting with some monorepo stuff here, and there's probably a better way to do this, but this should work just fine for now.

- Add `examples-deps-install.sh` to CircleCI scripts
  - Update CircleCI config
- Persist `examples/*/node_modules` in deps install job