### PR TITLE
Add dependency installation to example building script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,14 @@ module.exports = {
     },
     {
       files: [
+        'scripts/**/*.js',
+      ],
+      env: {
+        node: true,
+      },
+    },
+    {
+      files: [
         'examples/**/*.js',
       ],
       env: {

--- a/examples/identicon/package.json
+++ b/examples/identicon/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "identicon-plugin",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1",
-      "start": "mm-plugin serve"
+  "name": "identicon-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "mm-plugin serve"
+  },
+  "author": "",
+  "license": "ISC",
+  "web3Wallet": {
+    "bundle": {
+      "local": "dist/bundle.js",
+      "url": "https://mountainous-dentist.glitch.me/bundle.js"
     },
-    "author": "",
-    "license": "ISC",
-    "web3Wallet": {
-      "bundle": {
-        "local": "bundle.js",
-        "url": "https://mountainous-dentist.glitch.me/bundle.js"
-      },
-      "initialPermissions": {
-        "setUseBlockie": {}
-      }
-    },
-    "dependencies": {
-      "serve-handler": "^6.1.2",
-      "mm-plugin": "^0.3.13"
+    "initialPermissions": {
+      "setUseBlockie": {}
     }
+  },
+  "dependencies": {
+    "serve-handler": "^6.1.2",
+    "mm-plugin": "^0.3.13"
   }
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "generateInitTemplate": "node ./scripts/development/generateInitTemplate.js",
-    "buildExamples": "node ./scripts/buildExamples.js",
+    "dev:gen-init-template": "node ./scripts/development/generateInitTemplate.js",
+    "dev:build-examples": "node ./scripts/buildExamples.js",
     "lint": "eslint . --ext js,json",
     "lint:fix": "yarn lint --fix"
   },
@@ -28,7 +28,8 @@
     "eslint": "^7.18.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-json": "^2.1.2",
-    "eslint-plugin-node": "^11.1.0"
+    "eslint-plugin-node": "^11.1.0",
+    "execa": "^5.0.0"
   },
   "bin": {
     "snap": "./snaps-cli.js",

--- a/scripts/buildExamples.js
+++ b/scripts/buildExamples.js
@@ -1,7 +1,12 @@
 const { promises: fs } = require('fs');
 const path = require('path');
 
-const { bundle } = require('../src/build');
+const execa = require('execa');
+
+const { build } = require('../src/commands');
+
+// mock the snaps global
+global.snaps = {};
 
 const EXAMPLES_PATH = 'examples';
 
@@ -15,24 +20,34 @@ async function buildExamples() {
     const exampleFileStat = await fs.stat(exampleFilePath);
 
     if (exampleFileStat.isDirectory()) {
-      try {
-        const srcPath = path.resolve(exampleFilePath, 'index.js');
-        const pkgPath = path.resolve(exampleFilePath, 'package.json');
-        const pkgStat = await fs.stat(pkgPath);
-        const srcStat = await fs.stat(srcPath);
+      const srcPath = path.resolve(exampleFilePath, 'index.js');
+      const pkgPath = path.resolve(exampleFilePath, 'package.json');
+      const pkgStat = await fs.stat(pkgPath);
+      const srcStat = await fs.stat(srcPath);
 
-        if (pkgStat.isFile() && srcStat.isFile()) {
-          bundle(
-            srcPath,
-            path.resolve(exampleFilePath, 'dist/bundle.js'),
-            { sourceMaps: true },
-          );
-        } else {
-          throw new Error();
+      if (pkgStat.isFile() && srcStat.isFile()) {
+        try {
+          // install dependencies
+          await execa('yarn', [], {
+            cwd: exampleFilePath,
+          });
+        } catch (depsInstallError) {
+          console.log(`Unexpected error when installing dependences in "${exampleFilePath}.`);
+          throw depsInstallError;
         }
-      } catch (errors) {
-        console.log(`Invalid example folder found: ${exampleFile}`);
-        console.log(`Ensure it has valid 'package.json' and 'index.js' files.`);
+
+        try {
+          await build({
+            src: srcPath,
+            dist: path.resolve(exampleFilePath, 'dist'),
+            sourceMaps: true,
+          });
+        } catch (bundleError) {
+          console.log(`Unexpected error while creating bundle in "${exampleFilePath}.`);
+          throw bundleError;
+        }
+      } else {
+        throw new Error(`Invalid example directory "${exampleFile}". Ensure it has valid 'package.json' and 'index.js' files.`);
       }
     }
   });

--- a/src/build.js
+++ b/src/build.js
@@ -176,7 +176,7 @@ async function writeError(prefix, msg, err, destFilePath) {
       await fs.unlink(destFilePath);
     }
   } catch (unlinkError) {
-    logError(`${prefix}Failed to unlink mangled file.`, unlinkError);
+    logError(`${processedPrefix}Failed to unlink mangled file.`, unlinkError);
   }
 
   // unless the watcher is active, exit

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,7 +1268,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1671,6 +1671,21 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -1787,6 +1802,11 @@ get-intrinsic@^1.0.1, get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 glob-parent@^5.0.0:
   version "5.1.1"
@@ -1909,6 +1929,11 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 ieee754@^1.1.4:
   version "1.1.13"
@@ -2084,6 +2109,11 @@ is-regex@^1.1.1:
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-string@^1.0.5:
   version "1.0.5"
@@ -2275,6 +2305,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -2294,6 +2329,11 @@ mime-types@2.1.18:
   integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
   dependencies:
     mime-db "~1.33.0"
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -2395,6 +2435,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2446,6 +2493,13 @@ once@^1.3.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -2578,7 +2632,7 @@ path-is-inside@1.0.2:
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -2993,6 +3047,11 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
+signal-exit@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
+  integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
 simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
@@ -3166,6 +3225,11 @@ strip-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b"
   integrity sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Adds dependency installation by execution `yarn` in the shell to `buildExamples.js`
- Robustifies `buildExamples.js`
- Renames some dev scripts
- Fixes some minor issues in `build.js` and elsewhere