### PR TITLE
Remove environment option

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -106,15 +106,6 @@ const builders: Builders = {
     demandOption: false,
     default: false,
   },
-
-  environment: {
-    alias: 'env',
-    describe: 'The execution environment of the plugin.',
-    type: 'string',
-    demandOption: false,
-    default: 'worker',
-    choices: ['worker'],
-  },
 };
 
 export default builders;

--- a/src/cmds/build/index.ts
+++ b/src/cmds/build/index.ts
@@ -19,7 +19,6 @@ module.exports.builder = (yarg: yargs.Argv) => {
     .option('eval', builders.eval)
     .option('manifest', builders.manifest)
     .option('populate', builders.populate)
-    .option('environment', builders.environment)
     .implies('populate', 'manifest');
 };
 module.exports.handler = (argv: YargsArgs) => build(argv);

--- a/src/cmds/eval/index.ts
+++ b/src/cmds/eval/index.ts
@@ -9,8 +9,7 @@ module.exports.command = ['eval', 'e'];
 module.exports.desc = 'Attempt to evaluate Snap bundle in SES';
 module.exports.builder = (yarg: yargs.Argv) => {
   yarg
-    .option('bundle', builders.bundle)
-    .option('environment', builders.environment);
+    .option('bundle', builders.bundle);
 };
 module.exports.handler = (argv: YargsArgs) => snapEval(argv);
 

--- a/src/cmds/watch/index.ts
+++ b/src/cmds/watch/index.ts
@@ -13,7 +13,6 @@ module.exports.builder = (yarg: yargs.Argv) => {
     .option('dist', builders.dist)
     .option('outfileName', builders.outfileName)
     .option('sourceMaps', builders.sourceMaps)
-    .option('environment', builders.environment)
     .option('stripComments', builders.stripComments);
 };
 module.exports.handler = (argv: YargsArgs) => watch(argv);

--- a/src/types/package.d.ts
+++ b/src/types/package.d.ts
@@ -33,5 +33,4 @@ export interface Builders {
   readonly eval: Readonly<Options>;
   readonly verboseErrors: Readonly<Options>;
   readonly suppressWarnings: Readonly<Options>;
-  readonly environment: Readonly<Options>;
 }

--- a/test/utils/misc.test.js
+++ b/test/utils/misc.test.js
@@ -46,8 +46,6 @@ describe('misc', () => {
     'outfile-name': 'bundle.js',
     sourceMaps: false,
     'source-maps': false,
-    environment: 'worker',
-    env: 'worker',
     stripComments: false,
     strip: false,
     'strip-comments': false,


### PR DESCRIPTION
There is only one environment these days, so the `environment`/`env` option is useless. For now.