### PR TITLE
Restore crypto to eval environment

### DIFF
--- a/src/cmds/eval/evalWorker.ts
+++ b/src/cmds/eval/evalWorker.ts
@@ -1,6 +1,6 @@
 import { parentPort } from 'worker_threads';
 import { readFileSync } from 'fs';
-import cryptography from 'crypto';
+import crypto from 'crypto';
 
 // eslint-disable-next-line import/no-unassigned-import, @typescript-eslint/no-require-imports
 require('ses/lockdown');
@@ -35,7 +35,7 @@ function getMockApi() {
     },
     BigInt,
     setTimeout,
-    cryptography,
+    crypto,
     SubtleCrypto: () => undefined,
     fetch: () => true,
     XMLHttpRequest: () => true,
@@ -44,11 +44,11 @@ function getMockApi() {
     Date,
 
     window: {
-      cryptography,
+      crypto,
       SubtleCrypto: () => undefined,
       fetch: () => true,
       XMLHttpRequest: () => true,
       WebSocket: () => true,
     },
-  };
+  }
 }

--- a/src/cmds/eval/evalWorker.ts
+++ b/src/cmds/eval/evalWorker.ts
@@ -50,5 +50,5 @@ function getMockApi() {
       XMLHttpRequest: () => true,
       WebSocket: () => true,
     },
-  }
+  };
 }


### PR DESCRIPTION
During the TypeScript migration, the `crypto` endowment was renamed to `cryptography`. This broke stuff.