### PR TITLE
Prevent serve command from caching files

### DIFF
--- a/src/cmds/serve/index.ts
+++ b/src/cmds/serve/index.ts
@@ -35,7 +35,7 @@ async function serve(argv: YargsArgs): Promise<void> {
       public: root as string,
       headers: [
         {
-          source: '**/*.(html|js|json)',
+          source: '**/*',
           headers: [
             {
               key: 'Cache-Control',

--- a/src/cmds/serve/index.ts
+++ b/src/cmds/serve/index.ts
@@ -33,6 +33,17 @@ async function serve(argv: YargsArgs): Promise<void> {
   const server = http.createServer(async (req, res) => {
     await serveHandler(req, res, {
       public: root as string,
+      headers: [
+        {
+          source: '**/*.(html|js|json)',
+          headers: [
+            {
+              key: 'Cache-Control',
+              value: 'no-cache',
+            },
+          ],
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
This PR ensures that `mm-snap serve` will never cache any files. This prevents the browser from loading cached files even if they've changed on disk, which happened for me during local development.