### PR TITLE
Clear all mocks in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
 module.exports = {
-  testEnvironment: 'node',
-  verbose: false,
+  clearMocks: true,
   coverageReporters: [
     'json',
     'text',
     'html',
   ],
+  testEnvironment: 'node',
+  verbose: false,
 };

--- a/test/cmds/build/build.test.js
+++ b/test/cmds/build/build.test.js
@@ -7,7 +7,6 @@ const fsUtils = require('../../../dist/src/utils/validate-fs');
 describe('build', () => {
   describe('build', () => {
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 

--- a/test/cmds/build/bundle.test.js
+++ b/test/cmds/build/bundle.test.js
@@ -10,7 +10,6 @@ jest.mock('browserify');
 
 describe('bundle', () => {
   afterEach(() => {
-    jest.clearAllMocks();
     jest.restoreAllMocks();
   });
 

--- a/test/cmds/build/bundleUtils.test.js
+++ b/test/cmds/build/bundleUtils.test.js
@@ -26,7 +26,6 @@ describe('bundleUtils', () => {
     });
 
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 
@@ -60,7 +59,6 @@ describe('bundleUtils', () => {
     });
 
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 

--- a/test/cmds/init/initHandler.test.js
+++ b/test/cmds/init/initHandler.test.js
@@ -24,7 +24,6 @@ describe('initialize', () => {
     });
 
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
       delete global.snaps;
     });

--- a/test/cmds/init/initUtils.test.js
+++ b/test/cmds/init/initUtils.test.js
@@ -18,7 +18,6 @@ jest.mock('init-package-json');
 describe('initUtils', () => {
   describe('asyncPackageInit', () => {
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 
@@ -95,7 +94,6 @@ describe('initUtils', () => {
 
   describe('buildWeb3Wallet', () => {
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 
@@ -288,7 +286,6 @@ describe('initUtils', () => {
 
   describe('validateEmptyDir', () => {
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 

--- a/test/cmds/manifest/manifest.test.js
+++ b/test/cmds/manifest/manifest.test.js
@@ -53,7 +53,6 @@ describe('manifest', () => {
     });
 
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
     });
 

--- a/test/cmds/watch/watch.test.js
+++ b/test/cmds/watch/watch.test.js
@@ -32,7 +32,6 @@ describe('watch', () => {
     });
 
     afterEach(() => {
-      jest.clearAllMocks();
       jest.restoreAllMocks();
       watcherEmitter = undefined;
     });

--- a/test/utils/misc.test.js
+++ b/test/utils/misc.test.js
@@ -111,11 +111,6 @@ describe('misc', () => {
     global.snaps.isWatching = bool;
   };
 
-  beforeEach(() => {
-    jest.resetModules();
-    jest.resetAllMocks();
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/test/utils/readline.test.js
+++ b/test/utils/readline.test.js
@@ -26,7 +26,6 @@ describe('readline', () => {
     afterEach(() => {
       questionMock.mockRestore();
       questionMock = null;
-      closeMock.mockClear();
     });
 
     it('should open a prompt, read in user input from stdin, and return the trimmed input', async () => {

--- a/test/utils/validate-fs.test.js
+++ b/test/utils/validate-fs.test.js
@@ -2,7 +2,6 @@ const { getOutfilePath, validateOutfileName, validateFilePath, validateDirPath }
 const filesystem = require('../../dist/src/utils/fs');
 
 describe('validate', () => {
-
   afterEach(() => {
     jest.restoreAllMocks();
   });


### PR DESCRIPTION
Replaces all `clearAllMocks` and `mockClear` calls with `clearMocks: true` in the Jest config file. Also removes some other unnecessary mock-related calls.