### PR TITLE
Refactor package exports

### DIFF
--- a/development/buildExamples.js
+++ b/development/buildExamples.js
@@ -2,7 +2,7 @@ const { promises: fs } = require('fs');
 const { resolve } = require('path');
 const execa = require('execa');
 
-const { build } = require('../dist/cmds/build/buildHandler');
+const { build } = require('../dist/cmds');
 
 global.snaps = {
   verboseErrors: false,

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,8 +1,8 @@
 import yargs from 'yargs';
 import { cli } from './cli';
-import commands from './cmds';
+import { allCommands } from './cmds';
 
-const commandMap = ((commands as unknown) as yargs.CommandModule[]).reduce(
+const commandMap = ((allCommands as unknown) as yargs.CommandModule[]).reduce(
   (map, commandModule) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     map[commandModule.command![0]] = commandModule;
@@ -47,7 +47,7 @@ describe('cli', () => {
       throw new Error('process exited');
     });
 
-    expect(() => cli(getMockArgv('--help'), commands)).toThrow(
+    expect(() => cli(getMockArgv('--help'), allCommands)).toThrow(
       'process exited',
     );
   });
@@ -63,7 +63,7 @@ describe('cli', () => {
         resolve();
       });
 
-      cli(getMockArgv('--help'), commands);
+      cli(getMockArgv('--help'), allCommands);
     });
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,8 +1,8 @@
 import yargs from 'yargs';
 import { cli } from './cli';
-import { allCommands } from './cmds';
+import { commandModules } from './cmds';
 
-const commandMap = ((allCommands as unknown) as yargs.CommandModule[]).reduce(
+const commandMap = ((commandModules as unknown) as yargs.CommandModule[]).reduce(
   (map, commandModule) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     map[commandModule.command![0]] = commandModule;
@@ -47,7 +47,7 @@ describe('cli', () => {
       throw new Error('process exited');
     });
 
-    expect(() => cli(getMockArgv('--help'), allCommands)).toThrow(
+    expect(() => cli(getMockArgv('--help'), commandModules)).toThrow(
       'process exited',
     );
   });
@@ -63,7 +63,7 @@ describe('cli', () => {
         resolve();
       });
 
-      cli(getMockArgv('--help'), allCommands);
+      cli(getMockArgv('--help'), commandModules);
     });
   });
 

--- a/src/cmds/eval/index.ts
+++ b/src/cmds/eval/index.ts
@@ -4,7 +4,7 @@ import { YargsArgs } from '../../types/yargs';
 import { snapEval } from './evalHandler';
 
 export = {
-  command: ['eval', 'e'],
+  command: ['eval', 'evaluate', 'e'],
   desc: 'Attempt to evaluate Snap bundle in SES',
   builder: (yarg: yargs.Argv) => {
     yarg.option('bundle', builders.bundle);

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -13,6 +13,7 @@ export const commandModules = [
   serveModule,
   watchModule,
 ];
+
 export const build = buildModule.handler;
 export const evaluate = evaluateModule.handler;
 export const init = initModule.handler;

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -5,5 +5,5 @@ import manifest from './manifest';
 import serve from './serve';
 import watch from './watch';
 
-const commands = [init, build, evaluate, manifest, serve, watch];
-export default commands;
+export const allCommands = [init, build, evaluate, manifest, serve, watch];
+export { init, build, evaluate, manifest, serve, watch };

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -1,9 +1,21 @@
-import init from './init';
-import build from './build';
-import evaluate from './eval';
-import manifest from './manifest';
-import serve from './serve';
-import watch from './watch';
+import buildModule from './build';
+import evaluateModule from './eval';
+import initModule from './init';
+import manifestModule from './manifest';
+import serveModule from './serve';
+import watchModule from './watch';
 
-export const allCommands = [init, build, evaluate, manifest, serve, watch];
-export { init, build, evaluate, manifest, serve, watch };
+export const commandModules = [
+  buildModule,
+  evaluateModule,
+  initModule,
+  manifestModule,
+  serveModule,
+  watchModule,
+];
+export const build = buildModule.handler;
+export const evaluate = evaluateModule.handler;
+export const init = initModule.handler;
+export const manifest = manifestModule.handler;
+export const serve = serveModule.handler;
+export const watch = watchModule.handler;

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,5 @@
 import * as cliModule from './cli';
-import commands from './cmds';
+import { allCommands } from './cmds';
 
 jest.mock('./cli', () => ({
   cli: jest.fn(),
@@ -9,7 +9,7 @@ describe('main', () => {
   it('executes the CLI application', async () => {
     await import('./main');
     expect(cliModule.cli).toHaveBeenCalledTimes(1);
-    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, commands);
+    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, allCommands);
     expect(global.snaps).toStrictEqual({
       verboseErrors: false,
       suppressWarnings: false,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,5 @@
 import * as cliModule from './cli';
-import { allCommands } from './cmds';
+import { commandModules } from './cmds';
 
 jest.mock('./cli', () => ({
   cli: jest.fn(),
@@ -9,7 +9,7 @@ describe('main', () => {
   it('executes the CLI application', async () => {
     await import('./main');
     expect(cliModule.cli).toHaveBeenCalledTimes(1);
-    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, allCommands);
+    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, commandModules);
     expect(global.snaps).toStrictEqual({
       verboseErrors: false,
       suppressWarnings: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { cli } from './cli';
-import commands from './cmds';
+import { allCommands } from './cmds';
 
 global.snaps = {
   verboseErrors: false,
@@ -8,4 +8,4 @@ global.snaps = {
   isWatching: false,
 };
 
-cli(process.argv, commands);
+cli(process.argv, allCommands);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { cli } from './cli';
-import { allCommands } from './cmds';
+import { commandModules } from './cmds';
 
 global.snaps = {
   verboseErrors: false,
@@ -8,4 +8,4 @@ global.snaps = {
   isWatching: false,
 };
 
-cli(process.argv, allCommands);
+cli(process.argv, commandModules);


### PR DESCRIPTION
Refactors the package exports (i.e. the exports of the package manifest `main` file, which is `dist/cmds/index`) such that the complete command array is exported under the name `commandModules`, and every individual command handler is exported under one of its aliases. The default export is removed.