### PR TITLE
Remove main export

### DIFF
--- a/development/buildExamples.js
+++ b/development/buildExamples.js
@@ -2,7 +2,7 @@ const { promises: fs } = require('fs');
 const { resolve } = require('path');
 const execa = require('execa');
 
-const { build } = require('../dist/cmds');
+const { build } = require('../dist/cmds/build/buildHandler');
 
 global.snaps = {
   verboseErrors: false,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "snaps-cli",
   "version": "0.4.2",
   "description": "A CLI for developing MetaMask Snaps.",
-  "main": "./dist/cmds/index.js",
   "bin": {
     "mm-snap": "./dist/main.js"
   },

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,8 +1,8 @@
 import yargs from 'yargs';
 import { cli } from './cli';
-import { commandModules } from './cmds';
+import commands from './cmds';
 
-const commandMap = ((commandModules as unknown) as yargs.CommandModule[]).reduce(
+const commandMap = ((commands as unknown) as yargs.CommandModule[]).reduce(
   (map, commandModule) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     map[commandModule.command![0]] = commandModule;
@@ -47,7 +47,7 @@ describe('cli', () => {
       throw new Error('process exited');
     });
 
-    expect(() => cli(getMockArgv('--help'), commandModules)).toThrow(
+    expect(() => cli(getMockArgv('--help'), commands)).toThrow(
       'process exited',
     );
   });
@@ -63,7 +63,7 @@ describe('cli', () => {
         resolve();
       });
 
-      cli(getMockArgv('--help'), commandModules);
+      cli(getMockArgv('--help'), commands);
     });
   });
 

--- a/src/cmds/eval/index.ts
+++ b/src/cmds/eval/index.ts
@@ -4,7 +4,7 @@ import { YargsArgs } from '../../types/yargs';
 import { snapEval } from './evalHandler';
 
 export = {
-  command: ['eval', 'evaluate', 'e'],
+  command: ['eval', 'e'],
   desc: 'Attempt to evaluate Snap bundle in SES',
   builder: (yarg: yargs.Argv) => {
     yarg.option('bundle', builders.bundle);

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -1,9 +1,9 @@
-import init from './init';
 import build from './build';
 import evaluate from './eval';
+import init from './init';
 import manifest from './manifest';
 import serve from './serve';
 import watch from './watch';
 
-const commands = [init, build, evaluate, manifest, serve, watch];
+const commands = [build, evaluate, init, manifest, serve, watch];
 export default commands;

--- a/src/cmds/index.ts
+++ b/src/cmds/index.ts
@@ -1,22 +1,9 @@
-import buildModule from './build';
-import evaluateModule from './eval';
-import initModule from './init';
-import manifestModule from './manifest';
-import serveModule from './serve';
-import watchModule from './watch';
+import init from './init';
+import build from './build';
+import evaluate from './eval';
+import manifest from './manifest';
+import serve from './serve';
+import watch from './watch';
 
-export const commandModules = [
-  buildModule,
-  evaluateModule,
-  initModule,
-  manifestModule,
-  serveModule,
-  watchModule,
-];
-
-export const build = buildModule.handler;
-export const evaluate = evaluateModule.handler;
-export const init = initModule.handler;
-export const manifest = manifestModule.handler;
-export const serve = serveModule.handler;
-export const watch = watchModule.handler;
+const commands = [init, build, evaluate, manifest, serve, watch];
+export default commands;

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,5 @@
 import * as cliModule from './cli';
-import { commandModules } from './cmds';
+import commands from './cmds';
 
 jest.mock('./cli', () => ({
   cli: jest.fn(),
@@ -9,7 +9,7 @@ describe('main', () => {
   it('executes the CLI application', async () => {
     await import('./main');
     expect(cliModule.cli).toHaveBeenCalledTimes(1);
-    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, commandModules);
+    expect(cliModule.cli).toHaveBeenCalledWith(process.argv, commands);
     expect(global.snaps).toStrictEqual({
       verboseErrors: false,
       suppressWarnings: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { cli } from './cli';
-import { commandModules } from './cmds';
+import commands from './cmds';
 
 global.snaps = {
   verboseErrors: false,
@@ -8,4 +8,4 @@ global.snaps = {
   isWatching: false,
 };
 
-cli(process.argv, commandModules);
+cli(process.argv, commands);


### PR DESCRIPTION
This PR reverts #131, and completely removes the `main` field from the package manifest. We don't actually want to maintain any contract with consumers regarding our command module exports! The CLI itself is the interface. Packages that want to programmatically invoke `snaps-cli` can use `execa` or the command line.